### PR TITLE
Check instance support failed without resolving

### DIFF
--- a/src/Job/QlessJob.php
+++ b/src/Job/QlessJob.php
@@ -208,7 +208,8 @@ class QlessJob extends Job implements JobContract
 
         [$class, $method] = JobName::parse($payload['job']);
 
-        if (class_exists($class) && method_exists($this->instance = $this->resolve($class), 'failed')) {
+        if (class_exists($class) && method_exists($class, 'failed')) {
+            $this->instance = $this->resolve($class);
             $this->instance->failed($payload['data'], $e);
         }
     }

--- a/tests/Stub/JobWithOutFailedStub.php
+++ b/tests/Stub/JobWithOutFailedStub.php
@@ -1,0 +1,14 @@
+<?php
+namespace LaravelQless\Tests\Stub;
+
+/**
+ * Class JobWithOutFailedStub
+ * 
+ * @package LaravelQless\Tests\Stub
+ */
+class JobWithOutFailedStub
+{
+    public function fire()
+    {
+    }
+}


### PR DESCRIPTION
В продолжении [истории](https://github.com/pdffiller/laravel-queue-qless/pull/24) когда qless в поле klass присылает 'Qless\Jobs\BaseJob' и во время выполнения failed он пытается его зарезолвить. Но это невозможно сделать так как это класс котрый зависит не только от сервисов (конекшн к очереди), но еще и от данных джобы.

Так как подразумевается что метод failed должен быть публичным, то его наличие можно проверить и по имени класса не выполняя его resolving

P.S. Проблемма всплыла на signnow DEV environment так как qless UI заполняет переменную klass этим значением

