### PR TITLE
Fix $config visibility for Laravel v12.34+ compatibility

### DIFF
--- a/src/Queue/QlessQueue.php
+++ b/src/Queue/QlessQueue.php
@@ -29,7 +29,7 @@ class QlessQueue extends Queue implements QueueContract
     /**
      * @var array
      */
-    private $config;
+    protected $config;
 
     /** @var QlessConnectionHandler */
     private $clients;


### PR DESCRIPTION
The base Illuminate\Queue\Queue class introduced a protected $config property in v12.34.0. 
This change matches the visibility to fix the access level error.

See https://github.com/laravel/framework/blame/12.x/src/Illuminate/Queue/Queue.php#L46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal code structure for improved extensibility. No user-facing changes or impact on functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->